### PR TITLE
Removed Color Settings from main

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,4 @@
 {
-    "workbench.colorCustomizations": {
-        "activityBar.background": "#2D3008",
-        "titleBar.activeBackground": "#3F430C",
-        "titleBar.activeForeground": "#FAFBEA"
-    },
     "cSpell.words": [
         "crypted"
     ]


### PR DESCRIPTION
Removed the color settings that were made with the creation of the initial repository. No actual changes to the app itself.